### PR TITLE
Respect non-recursive directory processing

### DIFF
--- a/main.py
+++ b/main.py
@@ -188,8 +188,10 @@ async def process_directory(
     ]
 
     # Collect candidate files
+    directory = Path(directory_path)
+    candidates = directory.rglob("*") if recursive else directory.glob("*")
     candidate_files = [
-        p for p in Path(directory_path).rglob("*" if recursive else "*.*")
+        p for p in candidates
         if p.is_file() and p.suffix.lower() in exts
     ]
 


### PR DESCRIPTION
## Summary
- use `Path.glob()` when `process_directory(..., recursive=false)` collects candidate files
- keep `Path.rglob()` for recursive directory processing

## Verification
- native MCP `process_directory` with `file_extensions=[".md"]` and `recursive=false` sees only the top-level `README.md`

Fixes #6