### PR TITLE
Finalize RAG storages before clearing data

### DIFF
--- a/main.py
+++ b/main.py
@@ -312,7 +312,12 @@ async def clear_all_data(confirm: bool = False):
         return "Refused: pass confirm=True (CLI: --yes) to delete all stored data."
 
     global _global_rag
+    rag = _global_rag
     _global_rag = None  # drop the in-memory RAG so a fresh one is built later
+
+    if rag and rag.lightrag:
+        await rag.lightrag.finalize_storages()
+        rag.lightrag.auto_manage_storages_states = False
 
     for p in (SHARED_WORKDIR, OUTPUT_DIR):
         path = Path(p)               # ← ensure we have a Path object


### PR DESCRIPTION
## Summary
- preserve the active RAG instance before dropping `_global_rag`
- finalize active LightRAG storages before deleting workspace files
- disable auto-finalization on the stale LightRAG instance after explicit finalization

## Verification
- native MCP `clear_all_data(confirm=true)` returns success
- native MCP `get_workspace_info` works immediately after clear
- native MCP `check_doc_ingested` works immediately after clear and reports the document is not indexed

Fixes #9